### PR TITLE
Fix unit tests problems using Magento CLI

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     libjpeg62-turbo-dev \
     libmcrypt-dev \
     libpng12-dev \
+    mysql-client \
     libxslt1-dev
 
 RUN docker-php-ext-configure \

--- a/.docker/php/bin/mage-setup-raw
+++ b/.docker/php/bin/mage-setup-raw
@@ -3,6 +3,8 @@ echo "Initializing setup..."
 
 cd /var/www/html
 
+rm rf .keep
+
 if [ -f ./app/etc/config.php ] || [ -f ./app/etc/env.php ]; then
   echo "It appears Magento is already installed (app/etc/config.php or app/etc/env.php exist). Exiting setup..."
   exit

--- a/.docker/php/bin/magento
+++ b/.docker/php/bin/magento
@@ -1,2 +1,2 @@
 #!/bin/bash
-su -c "/usr/local/bin/php /var/www/html/bin/magento-php $*" -s /bin/sh www-data
+su -c "/usr/local/bin/php /var/www/html/bin/magento $*" -s /bin/sh www-data

--- a/.docker/php/bin/setup-config
+++ b/.docker/php/bin/setup-config
@@ -2,19 +2,14 @@
 BASE_DIR=/var/www
 SRC_DIR=$BASE_DIR/html
 
-if [ -d $SRC_DIR/bin ] && [ ! -f $SRC_DIR/bin/magento-php ]; then
-  mv $SRC_DIR/bin/magento $SRC_DIR/bin/magento-php
-  cp /usr/local/bin/magento $SRC_DIR/bin/
-fi
-
 if [ -d $BASE_DIR/.composer ]; then
   rm -rf $SRC_DIR/var/composer_home
   su -c "ln -s $BASE_DIR/.composer $SRC_DIR/var/composer_home" -s /bin/sh www-data
 fi
 
 echo "*/1 * * * * su -c \"/usr/local/bin/php $SRC_DIR/update/cron.php\" -s /bin/sh www-data > /proc/1/fd/2 2>&1" | crontab - \
-  && (crontab -l ; echo "*/1 * * * * su -c \"/usr/local/bin/php $SRC_DIR/bin/magento-php cron:run\" -s /bin/sh www-data > /proc/1/fd/2 2>&1") | crontab - \
-  && (crontab -l ; echo "*/1 * * * * su -c \"/usr/local/bin/php $SRC_DIR/bin/magento-php setup:cron:run\" -s /bin/sh www-data > /proc/1/fd/2 2>&1") | crontab -
+  && (crontab -l ; echo "*/1 * * * * su -c \"/usr/local/bin/php $SRC_DIR/bin/magento cron:run\" -s /bin/sh www-data > /proc/1/fd/2 2>&1") | crontab - \
+  && (crontab -l ; echo "*/1 * * * * su -c \"/usr/local/bin/php $SRC_DIR/bin/magento setup:cron:run\" -s /bin/sh www-data > /proc/1/fd/2 2>&1") | crontab -
 
 # Start the cron service
 /usr/sbin/cron

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please follow the next steps:
 
 6. Download and install Magento CE 2 with next command
 
-`docker-composer run setup`
+`docker-compose run setup`
 
 7. Add the next text in hosts file of your OS system:
 


### PR DESCRIPTION
- Fix unit tests problems using Magento CLI,  install mysql client for php container
- Fix empty composer directory problem when it's installed first time
- correct text on Readme.md